### PR TITLE
UPSTREAM: <carry>: Add OpenShift's Dockerfile

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,0 +1,24 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
+WORKDIR /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver
+COPY . .
+RUN make
+
+# TODO: use efs-utils base image when we have it in CI.
+# See https://github.com/openshift/enhancements/pull/687/files#diff-fffcbfb6a2861d40ec2fcb7eeb3ad97adca21044a9756c400e1764c1f06c30b7R202
+# Using jsafrane's private efs-utils.rpm, built manually from source.
+FROM quay.io/centos/centos:8
+RUN yum update -y && \
+    yum install --setopt=tsflags=nodocs -y https://people.redhat.com/jsafrane/amazon-efs-utils-1.31.2-1.el8.noarch.rpm && \
+    yum clean all && rm -rf /var/cache/yum/*
+# end of TODO
+
+# From the upstream Dockerfile:
+# At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
+# to be saved in another place so that the other stateful files created at runtime, i.e. private key for
+# client certificate, in the same config directory can be persisted to host with a host path volume.
+# Otherwise creating a host path volume for that directory will clean up everything inside at the first time.
+# Those static files need to be copied back to the config directory when the driver starts up.
+RUN mv /etc/amazon/efs /etc/amazon/efs-static-files
+
+COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/bin/aws-efs-csi-driver /usr/bin/
+ENTRYPOINT ["/usr/bin/aws-efs-csi-driver"]


### PR DESCRIPTION
With temporary installation of efs-utils from a custom RPM. This should be removed when we have a base image with efs-utils in CI.
