### PR TITLE
Bug 1999578: UPSTREAM: 548: Fix block provisioning

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -70,8 +71,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		return nil, status.Error(codes.InvalidArgument, "Volume capabilities not provided")
 	}
 
-	if !d.isValidVolumeCapabilities(volCaps) {
-		return nil, status.Error(codes.InvalidArgument, "Volume capabilities not supported")
+	if err := d.isValidVolumeCapabilities(volCaps); err != nil {
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Volume capabilities not supported: %s", err))
 	}
 
 	var (
@@ -358,7 +359,7 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 	}
 
 	var confirmed *csi.ValidateVolumeCapabilitiesResponse_Confirmed
-	if d.isValidVolumeCapabilities(volCaps) {
+	if err := d.isValidVolumeCapabilities(volCaps); err == nil {
 		confirmed = &csi.ValidateVolumeCapabilitiesResponse_Confirmed{VolumeCapabilities: volCaps}
 	}
 	return &csi.ValidateVolumeCapabilitiesResponse{

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -392,7 +392,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectMakeDir: false,
 			expectError: errtyp{
 				code:    "InvalidArgument",
-				message: "Volume capability not supported",
+				message: "Volume capability not supported: invalid access mode: SINGLE_NODE_READER_ONLY",
 			},
 		},
 		{
@@ -412,7 +412,7 @@ func TestNodePublishVolume(t *testing.T) {
 			expectMakeDir: false,
 			expectError: errtyp{
 				code:    "InvalidArgument",
-				message: "Volume capability access type must be mount",
+				message: "Volume capability not supported: only filesystem volumes are supported",
 			},
 		},
 		{


### PR DESCRIPTION
EFS CSI driver should return an error when CO tries to provision a block volume. The driver does not support block volumes.

When at it, improve error reporting a bit - let CO know what volume mode is not supported.

@openshift/storage 