### PR TITLE
UPSTREAM: <carry>: Ignore 'wait: no child processes' error when calling mount/umount

### DIFF
--- a/vendor/k8s.io/utils/mount/mount_linux.go
+++ b/vendor/k8s.io/utils/mount/mount_linux.go
@@ -43,6 +43,8 @@ const (
 	fsckErrorsCorrected = 1
 	// 'fsck' found errors but exited without correcting them
 	fsckErrorsUncorrected = 4
+	// Error thrown by exec cmd.Run() when process spawned by cmd.Start() completes before cmd.Wait() is called (see - k/k issue #103753)
+	errNoChildProcesses = "wait: no child processes"
 )
 
 // Mounter provides the default implementation of mount.Interface
@@ -147,6 +149,14 @@ func (mounter *Mounter) doMount(mounterPath string, mountCmd string, source stri
 	command := exec.Command(mountCmd, mountArgs...)
 	output, err := command.CombinedOutput()
 	if err != nil {
+		if err.Error() == errNoChildProcesses {
+			if command.ProcessState.Success() {
+				// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+				return nil
+			}
+			// Rewrite err with the actual exit error of the process.
+			err = &exec.ExitError{ProcessState: command.ProcessState}
+		}
 		klog.Errorf("Mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s\n", err, mountCmd, mountArgsLogStr, string(output))
 		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s",
 			err, mountCmd, mountArgsLogStr, string(output))
@@ -239,6 +249,14 @@ func (mounter *Mounter) Unmount(target string) error {
 	command := exec.Command("umount", target)
 	output, err := command.CombinedOutput()
 	if err != nil {
+		if err.Error() == errNoChildProcesses {
+			if command.ProcessState.Success() {
+				// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+				return nil
+			}
+			// Rewrite err with the actual exit error of the process.
+			err = &exec.ExitError{ProcessState: command.ProcessState}
+		}
 		return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))
 	}
 	return nil


### PR DESCRIPTION
Based on github.com/kubernetes/kubernetes/pull/103780.

This PR is not in the CSI driver repo yet, marking as `<carry>`. To be carried in OCP until the EFS CSI driver upstream updates k8s.io/mount-utils v1.23

cc @openshift/storage 