### PR TITLE
Bug 2043665: Trigger the CSI driver image rebuild

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,4 @@
 approvers:
 - openshift-storage-maintainers
 component: "Storage"
+


### PR DESCRIPTION
This PR is only supposed to start rebuild new CSI driver image to pull in new aws-efs-utils.