### PR TITLE
Bug 2063115: UPSTREAM: 645: go.mod: fix non-existing k8s.io/kubernetes version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/apimachinery v0.18.10
 	k8s.io/client-go v0.18.10
 	k8s.io/klog v1.0.0
-	k8s.io/kubernetes v1.23.10
+	k8s.io/kubernetes v1.18.10
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -773,7 +773,7 @@ k8s.io/kube-scheduler/extender/v1
 # k8s.io/kubectl v0.0.0 => k8s.io/kubectl v0.18.10
 ## explicit; go 1.13
 k8s.io/kubectl/pkg/scale
-# k8s.io/kubernetes v1.23.10
+# k8s.io/kubernetes v1.18.10
 ## explicit; go 1.13
 k8s.io/kubernetes/pkg/api/legacyscheme
 k8s.io/kubernetes/pkg/api/service


### PR DESCRIPTION
CC @openshift/storage 