### PR TITLE
UPSTREAM: 752: Update gofmt for go 1.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver
 COPY . .
 RUN make

--- a/pkg/driver/config_dir.go
+++ b/pkg/driver/config_dir.go
@@ -28,14 +28,15 @@ import (
 // (i.e. when the user does not need to durably store configs and thus does not mount host directories), an empty
 // directory will be created at etcAmazonEfs.
 //
-// - legacyDir    is the path to a config directory where previous versions of this driver may have written config
-//                files. In previous versions of this driver, a host path that was not writeable on Bottlerocket hosts
-//                was being used, so we introduce preferredDir.
+//   - legacyDir    is the path to a config directory where previous versions of this driver may have written config
+//     files. In previous versions of this driver, a host path that was not writeable on Bottlerocket hosts
+//     was being used, so we introduce preferredDir.
 //
 // - preferredDir is the path to config directory that we will use so long as we do not find files in legacyDir.
 //
-// - etcAmazonEfs is the path where the symlink will be written. In practice, this will always be /etc/amazon/efs, but
-//                we take it as an input so the function can be tested.
+//   - etcAmazonEfs is the path where the symlink will be written. In practice, this will always be /etc/amazon/efs, but
+//     we take it as an input so the function can be tested.
+//
 // Examples:
 // On a host that has EFS mounts created by an earlier version of this driver, InitConfigDir will detect a conf file in
 // legacyDir and write a symlink at etcAmazonEfs pointing to legacyDir.

--- a/pkg/driver/efs_watch_dog.go
+++ b/pkg/driver/efs_watch_dog.go
@@ -187,7 +187,8 @@ func (w *execWatchdog) setup(efsClientSource string) error {
 	return nil
 }
 
-/**
+/*
+*
 At image build time, static files installed by efs-utils in the config directory, i.e. CAs file, need
 to be saved in another place so that the other stateful files created at runtime, i.e. private key for
 client certificate, in the same config directory can be persisted to host with a host path volume.

--- a/pkg/driver/gid_allocator.go
+++ b/pkg/driver/gid_allocator.go
@@ -44,7 +44,7 @@ func NewGidAllocator() GidAllocator {
 	}
 }
 
-//Retrieves the next available GID
+// Retrieves the next available GID
 func (g *GidAllocator) getNextGid(fsId string, gidMin, gidMax int) (int, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -74,7 +74,7 @@ func (g *GidAllocator) releaseGid(fsId string, gid int) {
 	gidHeap.Push(gid)
 }
 
-//Creates an entry fsIdGidMap if fsId does not exist.
+// Creates an entry fsIdGidMap if fsId does not exist.
 func (g *GidAllocator) initFsId(fsId string, gidMin, gidMax int) {
 	h := initHeap(gidMin, gidMax)
 	heap.Init(h)
@@ -87,7 +87,7 @@ func (g *GidAllocator) removeFsId(fsId string) {
 	delete(g.fsIdGidMap, fsId)
 }
 
-//Initializes a heap inclusive of min & max
+// Initializes a heap inclusive of min & max
 func initHeap(min, max int) *IntHeap {
 	h := make(IntHeap, max-min+1)
 	val := min

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -375,11 +375,12 @@ func (d *Driver) validateFStype(volCaps []*csi.VolumeCapability) error {
 
 // parseVolumeId accepts a NodePublishVolumeRequest.VolumeId as a colon-delimited string of the
 // form `{fileSystemID}:{mountPath}:{accessPointID}`.
-// - The `{fileSystemID}` is required, and expected to be of the form `fs-...`.
-// - The other two fields are optional -- they may be empty or omitted entirely. For example,
-//   `fs-abcd1234::`, `fs-abcd1234:`, and `fs-abcd1234` are equivalent.
-// - The `{mountPath}`, if specified, is not required to be absolute.
-// - The `{accessPointID}` is expected to be of the form `fsap-...`.
+//   - The `{fileSystemID}` is required, and expected to be of the form `fs-...`.
+//   - The other two fields are optional -- they may be empty or omitted entirely. For example,
+//     `fs-abcd1234::`, `fs-abcd1234:`, and `fs-abcd1234` are equivalent.
+//   - The `{mountPath}`, if specified, is not required to be absolute.
+//   - The `{accessPointID}` is expected to be of the form `fsap-...`.
+//
 // parseVolumeId returns the parsed values, of which `subpath` and `apid` may be empty; and an
 // error, which will be a `status.Error` with `codes.InvalidArgument`, or `nil` if the `volumeId`
 // was parsed successfully.

--- a/pkg/driver/version.go
+++ b/pkg/driver/version.go
@@ -3,7 +3,9 @@ Copyright 2019 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/driver/version_test.go
+++ b/pkg/driver/version_test.go
@@ -3,7 +3,9 @@ Copyright 2019 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/driver/vol_statter.go
+++ b/pkg/driver/vol_statter.go
@@ -3,7 +3,9 @@ Copyright 2019 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
This is partial cherry-pick of https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/752, as we don't want the other documentation changes. It will fix gofmt for go 1.19 + update Dockerfile to be consistent with ART (https://github.com/openshift/aws-efs-csi-driver/pull/26)

@openshift/storage 