### PR TITLE
OCPBUGS-2822: UPSTREAM: <carry>: Fix GOARCH in OpenShift build

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-efs-csi-driver
 COPY . .
-RUN make
+RUN make bin/aws-efs-csi-driver
 
 # Use a base image with aws-efs-utils installed
 FROM registry.ci.openshift.org/ocp/4.12:aws-efs-utils-base

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,9 @@ word-hyphen = $(word $2,$(subst -, ,$1))
 .PHONY: linux/$(ARCH) bin/aws-efs-csi-driver
 linux/$(ARCH): bin/aws-efs-csi-driver
 bin/aws-efs-csi-driver: | bin
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(ARCH) go build -mod=vendor -ldflags ${LDFLAGS} -o bin/aws-efs-csi-driver ./cmd/
+# OpenShift: <carry>: do not overwrite GOARCH, use the one provided by the builder.
+	@echo GOARCH:${GOARCH}
+	CGO_ENABLED=0 GOOS=linux go build -mod=vendor -ldflags ${LDFLAGS} -o bin/aws-efs-csi-driver ./cmd/
 
 .PHONY: all
 all: all-image-docker


### PR DESCRIPTION
Do not overwrite `GOARCH`, it is set by our builders to the right value for x86_64 or arm or whatever we will support in OCP.

In addition, build just one `bin/aws-efs-csi-driver`, for the current arch. Don't build anything else.

@openshift/storage 