### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - troubleshooting/log_collector.py


### PR DESCRIPTION
Ignore these errors from log_collector.py. This is just a troubleshooting script and not part of the component that runs in production. While the user who runs the script could technically pass an unexpected command through to `execute()`... there is really no benefit to doing so since it would still run those commands under their user id. They could just run that command directly instead.

```
 ✗ [Medium] Command Injection
   ID: 19f2baf0-7200-4734-abcc-2bfe50034d1b 
   Path: troubleshooting/log_collector.py, line 27 
   Info: Unsanitized input from a command line argument flows into subprocess.run, where it is used as a shell command. This may result in a Command Injection vulnerability.
 ✗ [Medium] Command Injection
   ID: c4284270-3357-46cf-aed1-7fc92829bbeb 
   Path: troubleshooting/log_collector.py, line 29 
   Info: Unsanitized input from a command line argument flows into subprocess.run, where it is used as a shell command. This may result in a Command Injection vulnerability.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-aws-efs-csi-driver-master-security/1745954191110574080

/cc @openshift/storage
