### PR TITLE
OCPBUGS-34843: UPSTREAM: 1180: Fixed Posixuser nil pointer dereference issue

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -311,14 +311,20 @@ func (c *cloud) ListAccessPoints(ctx context.Context, fileSystemId string) (acce
 		return
 	}
 
+	var posixUser *PosixUser
 	for _, accessPointDescription := range res.AccessPoints {
+		if accessPointDescription.PosixUser != nil {
+			posixUser = &PosixUser{
+				Gid: *accessPointDescription.PosixUser.Gid,
+				Uid: *accessPointDescription.PosixUser.Gid,
+			}
+		} else {
+			posixUser = nil
+		}
 		accessPoint := &AccessPoint{
 			AccessPointId: *accessPointDescription.AccessPointId,
 			FileSystemId:  *accessPointDescription.FileSystemId,
-			PosixUser: &PosixUser{
-				Gid: *accessPointDescription.PosixUser.Gid,
-				Uid: *accessPointDescription.PosixUser.Gid,
-			},
+			PosixUser:     posixUser,
 		}
 		accessPoints = append(accessPoints, accessPoint)
 	}

--- a/pkg/driver/gid_allocator.go
+++ b/pkg/driver/gid_allocator.go
@@ -72,11 +72,9 @@ func (g *GidAllocator) getUsedGids(ctx context.Context, localCloud cloud.Cloud, 
 		if ap == nil {
 			continue
 		}
-		if ap != nil && ap.PosixUser == nil {
-			err = fmt.Errorf("failed to discover used GID because PosixUser is nil for AccessPoint: %s", ap.AccessPointId)
-			return
+		if ap.PosixUser != nil {
+			gids = append(gids, ap.PosixUser.Gid)
 		}
-		gids = append(gids, ap.PosixUser.Gid)
 	}
 	klog.V(5).Infof("Discovered used GIDs: %+v for FS ID: %v", gids, fsId)
 	return


### PR DESCRIPTION
This is a cherry-pick of upstream fix https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1180 to 4.15.z.

Fix is included in upstream driver versions v1.7.1+ and 4.16 is based on upstream driver v1.7.3 so this should not regress when upgrading 4.15 -> 4.16.

## Verification

### Setup

Make sure we have an existing access point that does not have `POSIX user` set. That way driver actually loads nil posix user from AWS which is required to hit the bug: 
```
$ aws efs describe-access-points --file-system-id fs-00d7ce85719d8f844 --output json
{
    "AccessPoints": [
        {
            "ClientToken": "console-c9a1bfd8-b40d-4f45-b50c-bdf6c6fb029f",
            "Tags": [],
            "AccessPointId": "fsap-04cfa1d5191713661",
            "AccessPointArn": "arn:aws:elasticfilesystem:us-east-1:269733383066:access-point/fsap-04cfa1d5191713661",
            "FileSystemId": "fs-00d7ce85719d8f844",
            "RootDirectory": {
                "Path": "/"
            },
            "OwnerId": "269733383066",
            "LifeCycleState": "available"
        },
```


Storage class used:
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2024-06-06T12:10:46Z"
  name: efs-sc
  resourceVersion: "66084"
  uid: eed0de64-fd0c-46bd-9f15-1587ecfac40f
mountOptions:
- tls
parameters:
  basePath: /dynamic_provisioning
  directoryPerms: "700"
  fileSystemId: fs-00d7ce85719d8f844
  provisioningMode: efs-ap
provisioner: efs.csi.aws.com
reclaimPolicy: Delete
volumeBindingMode: Immediate
```

### Before fix

Volume not provisioned:
```
oc get pvc/pvc-1
NAME    STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc-1   Pending                                      efs-sc         7m34s
```

Controller pod panics:
```
$ oc -n openshift-cluster-csi-drivers logs aws-efs-csi-driver-controller-6d5c544859-5k6ft --previous | tail -n 25
Defaulted container "csi-driver" out of: csi-driver, csi-provisioner, provisioner-kube-rbac-proxy, csi-liveness-probe
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x17577a0]

goroutine 1817 [running]:
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud.(*cloud).ListAccessPoints(0xc000785320, {0x2029580, 0xc0004fd2c0}, {0xc00004a468, 0x14})
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/cloud/cloud.go:319 +0x320
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver.(*GidAllocator).getUsedGids(0x6acfc0?, {0x2029580?, 0xc0004fd2c0?}, {0x202d8a0?, 0xc000785320?}, {0xc00004a468, 0x14})
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/gid_allocator.go:62 +0x65
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver.(*GidAllocator).getNextGid(0xc0001cc158, {0x2029580, 0xc0004fd2c0}, {0x202d8a0, 0xc000785320}, {0xc00004a468, 0x14}, 0x3621e0?, 0x0?)
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/gid_allocator.go:38 +0x21c
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver.(*Driver).CreateVolume(0xc0001cc0c0, {0x2029580, 0xc0004fd2c0}, 0xc000412460)
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/controller.go:257 +0x150e
github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler.func1({0x2029580, 0xc0004fd2c0}, {0x1b4a380?, 0xc000412460})
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi.pb.go:5678 +0x78
github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver.(*Driver).Run.func1({0x2029580?, 0xc0004fd2c0?}, {0x1b4a380?, 0xc000412460?}, 0xc0005aba00?, 0x19c3d80?)
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/pkg/driver/driver.go:101 +0x42
github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler({0x1bb7f20?, 0xc0001cc0c0}, {0x2029580, 0xc0004fd2c0}, 0xc0007a0680, 0x1d19298)
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi.pb.go:5680 +0x138
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001d6000, {0x2029580, 0xc0004fd200}, {0x202f540, 0xc000009ba0}, 0xc00067e360, 0xc00065a900, 0x2f32360, 0x0)
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/vendor/google.golang.org/grpc/server.go:1343 +0xe49
google.golang.org/grpc.(*Server).handleStream(0xc0001d6000, {0x202f540, 0xc000009ba0}, 0xc00067e360)
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/vendor/google.golang.org/grpc/server.go:1737 +0xca6
google.golang.org/grpc.(*Server).serveStreams.func1.1()
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/vendor/google.golang.org/grpc/server.go:986 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/go/src/github.com/kubernetes-sigs/aws-efs-csi-driver/vendor/google.golang.org/grpc/server.go:997 +0x15c
```

### After fix

PVC provisioned:
```
$ oc get pvc/pvc-1
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc-1   Bound    pvc-f20ba93f-b471-4dd9-9515-a8380c225a82   1Gi        RWO            efs-sc         9s
```

Driver controller pod logs (no panic):
```
$ oc -n openshift-cluster-csi-drivers logs aws-efs-csi-driver-controller-588977474f-p8ncv | tail -n 8
Defaulted container "csi-driver" out of: csi-driver, csi-provisioner, provisioner-kube-rbac-proxy, csi-liveness-probe
I0606 13:07:57.864518       1 driver.go:127] Listening for connections on address: &net.UnixAddr{Name:"/var/lib/csi/sockets/pluginproxy/csi.sock", Net:"unix"}
W0606 13:10:29.680804       1 gid_allocator.go:88] Requested GID range (50000:7000000) exceeds EFS Access Point limit (1000) per Filesystem. Driver will use limited GID range (50000:51000)
I0606 13:10:29.680839       1 controller.go:296] Using PV name for access point directory.
I0606 13:10:29.680850       1 controller.go:303] Using /dynamic_provisioning/pvc-cb4c116c-ba12-4001-be78-fbcc06c0a767 as the access point directory.
I0606 13:12:50.882095       1 mount_linux.go:254] Cannot run systemd-run, assuming non-systemd OS
W0606 13:13:01.841162       1 gid_allocator.go:88] Requested GID range (50000:7000000) exceeds EFS Access Point limit (1000) per Filesystem. Driver will use limited GID range (50000:51000)
I0606 13:13:01.841194       1 controller.go:296] Using PV name for access point directory.
I0606 13:13:01.841207       1 controller.go:303] Using /dynamic_provisioning/pvc-f20ba93f-b471-4dd9-9515-a8380c225a82 as the access point directory.
```

Check EFS access points in AWS:
```
$ aws efs describe-access-points --file-system-id fs-00d7ce85719d8f844 --output json
{
    "AccessPoints": [
        {
            "ClientToken": "console-c9a1bfd8-b40d-4f45-b50c-bdf6c6fb029f",
            "Tags": [],
            "AccessPointId": "fsap-04cfa1d5191713661",
            "AccessPointArn": "arn:aws:elasticfilesystem:us-east-1:269733383066:access-point/fsap-04cfa1d5191713661",
            "FileSystemId": "fs-00d7ce85719d8f844",
            "RootDirectory": {
                "Path": "/"
            },
            "OwnerId": "269733383066",
            "LifeCycleState": "available"
        },
        {
            "ClientToken": "pvc-f20ba93f-b471-4dd9-9515-a8380c225a82",
            "Tags": [
                {
                    "Key": "efs.csi.aws.com/cluster",
                    "Value": "true"
                },
                {
                    "Key": "kubernetes.io/cluster/rbednar-mycluster-01-qjjwv",
                    "Value": "owned"
                }
            ],
            "AccessPointId": "fsap-0e368fef6976e22b0",
            "AccessPointArn": "arn:aws:elasticfilesystem:us-east-1:269733383066:access-point/fsap-0e368fef6976e22b0",
            "FileSystemId": "fs-00d7ce85719d8f844",
            "PosixUser": {
                "Uid": 50000,
                "Gid": 50000
            },
            "RootDirectory": {
                "Path": "/dynamic_provisioning/pvc-f20ba93f-b471-4dd9-9515-a8380c225a82",
                "CreationInfo": {
                    "OwnerUid": 50000,
                    "OwnerGid": 50000,
                    "Permissions": "700"
                }
            },
            "OwnerId": "269733383066",
            "LifeCycleState": "available"
        }
    ]
}
```