### PR TITLE
OCPBUGS-61306: Modify delete access point root directory logic to only remove temporary directory if empty

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -417,8 +417,8 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not unmount %q: %v", target, err)
 			}
-			err = os.RemoveAll(target)
-			if err != nil {
+			err = os.Remove(target)
+			if err != nil && !os.IsNotExist(err) {
 				return nil, status.Errorf(codes.Internal, "Could not delete %q: %v", target, err)
 			}
 		}


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/aws-efs-csi-driver/commit/7693a4e247e176ba0df9ba9c1158647b7276784b to 4.16